### PR TITLE
feat: centralize resend email service

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ npm i
 npm run dev
 ```
 
+## Environment variables
+
+This project uses [Resend](https://resend.com) for transactional emails. To enable email sending, set the following environment variable before running the app:
+
+```sh
+export VITE_RESEND_API_KEY="your_resend_api_key"
+```
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/supabase/functions/_shared/resend.ts
+++ b/supabase/functions/_shared/resend.ts
@@ -1,0 +1,9 @@
+import { Resend } from 'npm:resend@4.0.0'
+
+const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY') || ''
+
+if (!RESEND_API_KEY) {
+  console.warn('RESEND_API_KEY is not set')
+}
+
+export const resend = new Resend(RESEND_API_KEY)

--- a/supabase/functions/send-confirmation/index.ts
+++ b/supabase/functions/send-confirmation/index.ts
@@ -1,10 +1,8 @@
 import React from 'npm:react@18.3.1'
 import { Webhook } from 'https://esm.sh/standardwebhooks@1.0.0'
-import { Resend } from 'npm:resend@4.0.0'
 import { renderAsync } from 'npm:@react-email/components@0.0.22'
 import { WelcomeEmail } from './_templates/welcome-email.tsx'
-
-const resend = new Resend(Deno.env.get('RESEND_API_KEY') as string)
+import { resend } from '../_shared/resend.ts'
 const hookSecret = Deno.env.get('SEND_EMAIL_HOOK_SECRET') as string
 
 const corsHeaders = {

--- a/supabase/functions/welcome-email/index.ts
+++ b/supabase/functions/welcome-email/index.ts
@@ -1,8 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { Resend } from "npm:resend@2.0.0";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const resend = new Resend(Deno.env.get("RESEND_API_KEY"));
+import { resend } from "../_shared/resend.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
## Summary
- centralize Resend client for serverless functions
- update welcome and confirmation emails to use shared service
- document RESEND configuration for local setup

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a6a104553c832ab96ac79b000ae41e