### PR TITLE
Support deriving Supabase URL from DB connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ This project uses [Resend](https://resend.com) for transactional emails. To enab
 export VITE_RESEND_API_KEY="your_resend_api_key"
 ```
 
+Supabase is used for authentication and data storage. Configure these variables to connect to your Supabase project:
+
+```sh
+export VITE_SUPABASE_URL="https://YOUR_PROJECT_REF.supabase.co"
+export VITE_SUPABASE_ANON_KEY="your_supabase_anon_key"
+
+# Optional: supply a database connection string instead of VITE_SUPABASE_URL
+export VITE_SUPABASE_DB_URL="postgresql://user:password@host:5432/postgres"
+```
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,16 +2,39 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://zwxyoeqsbntsogvgwily.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp3eHlvZXFzYm50c29ndmd3aWx5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU5ODQ4NzksImV4cCI6MjA3MTU2MDg3OX0.hGZQHoXS_3RaoKpZcz6W8BNNYBt6QnyJMpTJ9HCvpW8";
+// Use environment variables so the client works across different deployments
+let SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const SUPABASE_DB_URL = import.meta.env
+  .VITE_SUPABASE_DB_URL as string | undefined;
+const SUPABASE_ANON_KEY = import.meta.env
+  .VITE_SUPABASE_ANON_KEY as string | undefined;
+
+// Allow deriving the project URL from a provided database connection string
+if (!SUPABASE_URL && SUPABASE_DB_URL) {
+  try {
+    const { username } = new URL(SUPABASE_DB_URL);
+    const projectRef = username.split('.')[1];
+    SUPABASE_URL = `https://${projectRef}.supabase.co`;
+  } catch {
+    // ignore parsing errors
+  }
+}
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  throw new Error('Missing Supabase environment variables');
+}
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
-  auth: {
-    storage: localStorage,
-    persistSession: true,
-    autoRefreshToken: true,
-  }
-});
+export const supabase = createClient<Database>(
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  {
+    auth: {
+      storage: typeof window !== 'undefined' ? window.localStorage : undefined,
+      persistSession: true,
+      autoRefreshToken: true,
+    },
+  },
+);


### PR DESCRIPTION
## Summary
- derive Supabase project URL from VITE_SUPABASE_DB_URL when VITE_SUPABASE_URL is unset
- rename publishable key env var to VITE_SUPABASE_ANON_KEY
- document Supabase environment variables in README

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aa7b07a6ac832a8bc4aca7889afb52