### PR TITLE
feat: add dashboard theme color selector

### DIFF
--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import { applyUserTheme, loadTheme, saveTheme, type ThemePreset } from "@/lib/theme";
 
-const presets: { key: ThemePreset; name: string }[] = [
-  { key: "emerald", name: "Emerald" },
-  { key: "blue", name: "Blue" },
-  { key: "violet", name: "Violet" },
+const presets: { key: ThemePreset; name: string; color: string }[] = [
+  { key: "emerald", name: "Emerald", color: "hsl(160, 51%, 58%)" },
+  { key: "blue", name: "Blue", color: "hsl(210, 100%, 60%)" },
+  { key: "violet", name: "Violet", color: "hsl(270, 90%, 65%)" },
 ];
 
 export default function ThemeSwitcher() {
@@ -18,16 +18,18 @@ export default function ThemeSwitcher() {
   }
 
   return (
-    <div className="flex gap-2 flex-wrap">
+    <div className="flex gap-3 flex-wrap">
       {presets.map((p) => (
         <button
           key={p.key}
           type="button"
+          aria-label={p.name}
           onClick={() => change(p.key)}
-          className={`button-secondary ${preset === p.key ? "ring-2 ring-primary" : ""}`}
-        >
-          {p.name}
-        </button>
+          className={`w-8 h-8 rounded-full border-2 border-transparent transition-all ${
+            preset === p.key ? "ring-2 ring-offset-2 ring-primary" : ""
+          }`}
+          style={{ backgroundColor: p.color }}
+        />
       ))}
     </div>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -33,6 +33,9 @@ const Dashboard: React.FC = () => {
 
           <div className="cyber-card p-6 hover-glow">
             <h2 className="text-lg font-semibold mb-3">Theme</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              Choose a color scheme for your dashboard.
+            </p>
             <ThemeSwitcher />
           </div>
 


### PR DESCRIPTION
## Summary
- improve theme switcher with color swatch buttons
- describe color selection in dashboard UI card

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68aab4600d34832a88c5a372d294dd75