### PR TITLE
refactor: expose auth results

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "npm run lint && npm run build"
   },
   "dependencies": {
     "@capacitor/android": "^7.4.2",

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,18 +1,25 @@
 /* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useContext, ReactNode } from 'react';
-import { useAuth } from '@/hooks/useAuth';
-import { User, Session, AuthError } from '@supabase/supabase-js';
+import { useAuth, AuthResult } from '@/hooks/useAuth';
+import { User, Session, AuthError, OAuthResponse } from '@supabase/supabase-js';
 
 interface AuthContextType {
   user: User | null;
   session: Session | null;
   loading: boolean;
   isAuthenticated: boolean;
-  signIn: (email: string, password: string) => Promise<{ error: AuthError | null }>;
-  signUp: (email: string, password: string, userData?: any) => Promise<{ error: AuthError | null }>;
-  signOut: () => Promise<{ error: AuthError | null }>;
-  resetPassword: (email: string) => Promise<{ error: AuthError | null }>;
-  signInWithOAuth: (provider: 'google' | 'azure' | 'github' | 'custom') => Promise<{ error: AuthError | null }>;
+  signIn: (email: string, password: string) => Promise<AuthResult<User>>;
+  signUp: (
+    email: string,
+    password: string,
+    userData?: Record<string, any>,
+  ) => Promise<AuthResult<User>>;
+  signOut: () => Promise<AuthResult<null>>;
+  resetPassword: (email: string) => Promise<AuthResult<null>>;
+  signInWithOAuth: (
+    provider: 'google' | 'azure' | 'github' | 'custom',
+    redirectTo?: string,
+  ) => Promise<AuthResult<OAuthResponse>>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);


### PR DESCRIPTION
## Summary
- export `AuthResult` interface and propagate typed auth results from `useAuth`
- update `AuthProvider` to surface typed sign-in, sign-up, sign-out, reset password, and OAuth helpers
- defer auth state until a Supabase session exists to avoid unconfirmed sign-ups appearing authenticated
- add `npm test` script that runs lint and build

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68ab3c5eaa58832ab044a5da2c68584f