### PR TITLE
feat: improve sign-up error handling

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -107,6 +107,15 @@ export default function Auth() {
         return;
       }
 
+      if (password !== confirmPassword) {
+        toast({
+          title: "Passwords don't match",
+          description: "Please make sure your passwords match.",
+          variant: "destructive"
+        });
+        return;
+      }
+
       if (!acceptTerms) {
         toast({
           title: "Terms required",
@@ -209,10 +218,27 @@ export default function Auth() {
         if (!result.error) {
           setShowEmailConfirmation(true);
         } else if (result.error.message.includes("User already registered")) {
+          toast({
+            title: "Account already exists",
+            description: "Please sign in to continue.",
+          });
           setMode("signin");
+        } else {
+          toast({
+            title: "Sign up failed",
+            description: result.error.message,
+            variant: "destructive",
+          });
         }
       } else {
         result = await signIn(email, password);
+        if (result.error) {
+          toast({
+            title: "Sign in failed",
+            description: result.error.message,
+            variant: "destructive",
+          });
+        }
       }
       
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- add confirm password check to registration
- show toast errors for sign-up and sign-in failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab8e0bce00832abb88cf8bb802cc2f