### PR TITLE
Add registration page with expanded OAuth and Supabase stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ This project uses [Resend](https://resend.com) for transactional emails. To enab
 export VITE_RESEND_API_KEY="your_resend_api_key"
 ```
 
+Supabase powers authentication and realtime data. You'll need to configure your project's URL and public anon key:
+
+```sh
+export VITE_SUPABASE_URL="https://your-project.supabase.co"
+export VITE_SUPABASE_PUBLISHABLE_KEY="your_public_anon_key"
+```
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import AuthConfiguration from "./pages/AuthConfiguration";
 import Settings from "./pages/Settings";
 import Setup from "./pages/Setup";
 import Auth from "./pages/Auth";
+import Register from "./pages/Register";
 import ResetPassword from "./pages/ResetPassword";
 import NotFound from "./pages/NotFound";
 import Policy from "./pages/Policy";
@@ -57,6 +58,7 @@ function App() {
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/auth" element={<Auth />} />
+              <Route path="/register" element={<Register />} />
               <Route path="/auth/callback" element={<AuthCallbackHandler />} />
               <Route path="/auth/reset-password" element={<ResetPassword />} />
               <Route path="/setup" element={

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useContext, ReactNode } from 'react';
 import { useAuth, AuthResult } from '@/hooks/useAuth';
-import { User, Session, AuthError, OAuthResponse } from '@supabase/supabase-js';
+import { User, Session, OAuthResponse } from '@supabase/supabase-js';
 
 interface AuthContextType {
   user: User | null;
@@ -17,9 +17,9 @@ interface AuthContextType {
   signOut: () => Promise<AuthResult<null>>;
   resetPassword: (email: string) => Promise<AuthResult<null>>;
   signInWithOAuth: (
-    provider: 'google' | 'azure' | 'github',
+    provider: 'google' | 'github' | 'apple',
     redirectTo?: string,
-  ) => Promise<AuthResult<any>>;
+  ) => Promise<AuthResult<OAuthResponse>>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -86,9 +86,9 @@ export function useAuth() {
   };
 
   const signInWithOAuth = async (
-    provider: 'google' | 'azure' | 'github',
+    provider: 'google' | 'github' | 'apple',
     redirectTo: string = window.location.origin
-  ): Promise<AuthResult<any>> => {
+  ): Promise<AuthResult<OAuthResponse>> => {
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider,
       options: { redirectTo },

--- a/src/hooks/useOAuthProviders.tsx
+++ b/src/hooks/useOAuthProviders.tsx
@@ -1,12 +1,57 @@
+import { useEffect, useState } from "react";
+
+type Provider = "google" | "github" | "apple";
+
 export function useOAuthProviders() {
-  return {
-    providers: [],
-    enabledProviders: {
-      google: false,
-      custom: false,
-      azure: false
-    },
-    loading: false,
-    validateProvider: () => true
-  };
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadProviders = async () => {
+      try {
+        const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+        const key = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string | undefined;
+
+        if (!url || !key) throw new Error("Missing Supabase env vars");
+
+        const res = await fetch(`${url}/auth/v1/settings`, {
+          headers: {
+            apikey: key,
+            Authorization: `Bearer ${key}`,
+          },
+        });
+
+        if (res.ok) {
+          const data = await res.json();
+          const external = data?.external ?? {};
+
+          const active: Provider[] = [];
+          if (external.google?.enabled) active.push("google");
+          if (external.github?.enabled) active.push("github");
+          if (external.apple?.enabled) active.push("apple");
+          setProviders(active);
+        } else {
+          // If settings can't be fetched, enable all providers by default
+          setProviders(["google", "github", "apple"]);
+        }
+      } catch (err) {
+        console.warn("Unable to determine OAuth providers, defaulting to all", err);
+        setProviders(["google", "github", "apple"]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadProviders();
+  }, []);
+
+  const enabledProviders = {
+    google: providers.includes("google"),
+    github: providers.includes("github"),
+    apple: providers.includes("apple"),
+  } as const;
+
+  const validateProvider = (provider: Provider) => enabledProviders[provider];
+
+  return { providers, enabledProviders, loading, validateProvider };
 }

--- a/src/hooks/useSupabaseStats.ts
+++ b/src/hooks/useSupabaseStats.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface SupabaseStats {
+  projects: number;
+  clients: number;
+}
+
+async function fetchStats(): Promise<SupabaseStats> {
+  const [projectRes, clientRes] = await Promise.all([
+    supabase.from('projects').select('*', { count: 'exact', head: true }),
+    supabase.from('clients').select('*', { count: 'exact', head: true }),
+  ]);
+
+  if (projectRes.error || clientRes.error) {
+    throw new Error(
+      projectRes.error?.message || clientRes.error?.message || 'Failed to load stats',
+    );
+  }
+
+  return {
+    projects: projectRes.count ?? 0,
+    clients: clientRes.count ?? 0,
+  };
+}
+
+export function useSupabaseStats() {
+  return useQuery({
+    queryKey: ['supabase-stats'],
+    queryFn: fetchStats,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -9,9 +9,9 @@ import { PasswordSecurityBannerFixed } from "@/components/PasswordSecurityBanner
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { supabase } from "@/integrations/supabase/client";
-import { Eye, EyeOff, Mail, Loader2, Shield } from "lucide-react";
+import { Eye, EyeOff, Mail, Loader2, Shield, Github, Apple } from "lucide-react";
 
-export default function Auth() {
+export default function Auth({ defaultMode = "signin" }: { defaultMode?: "signin" | "signup" | "forgot" }) {
   const { toast } = useToast();
   const navigate = useNavigate();
   const location = useLocation() as any;
@@ -19,7 +19,7 @@ export default function Auth() {
   const { isAuthenticated, signIn, signUp, signInWithOAuth, loading: authLoading } = useAuthContext();
   const { enabledProviders, loading: providersLoading } = useOAuthProviders();
 
-  const [mode, setMode] = useState<"signin"|"signup"|"forgot">("signin");
+  const [mode, setMode] = useState<"signin"|"signup"|"forgot">(defaultMode);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -40,7 +40,7 @@ export default function Auth() {
   }, [isAuthenticated, authLoading, navigate, redirectTo]);
 
   // Enhanced OAuth handler with proper error handling
-  const handleOAuthProvider = async (provider: 'google' | 'azure') => {
+  const handleOAuthProvider = async (provider: 'google' | 'github' | 'apple') => {
     setLoading(true);
     try {
       const { error } = await signInWithOAuth(provider);
@@ -328,32 +328,76 @@ export default function Auth() {
             <>
               {/* OAuth Providers */}
               <div className="space-y-3 mb-6">
-                {enabledProviders.google && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="w-full h-12 text-sm font-medium hover:bg-muted/50 transition-colors"
-                    onClick={() => handleOAuthProvider('google')}
-                    disabled={loading}
-                  >
-                    {loading ? (
-                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                    ) : (
-                      <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
-                        <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                        <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                        <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                        <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                      </svg>
-                    )}
-                    Continue with Google
-                  </Button>
-                )}
-
-                {!enabledProviders.google && !enabledProviders.azure && (
-                  <div className="text-center py-4">
-                    <p className="text-sm text-muted-foreground">OAuth providers not configured</p>
+                {providersLoading ? (
+                  <div className="flex justify-center py-2">
+                    <Loader2 className="w-5 h-5 animate-spin" />
                   </div>
+                ) : (
+                  <>
+                    {enabledProviders.google && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full h-12 text-sm font-medium hover:bg-muted/50 transition-colors"
+                        onClick={() => handleOAuthProvider('google')}
+                        disabled={loading || providersLoading}
+                      >
+                        {loading ? (
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        ) : (
+                          <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
+                            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                          </svg>
+                        )}
+                        Continue with Google
+                      </Button>
+                    )}
+
+                    {enabledProviders.github && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full h-12 text-sm font-medium hover:bg-muted/50 transition-colors"
+                        onClick={() => handleOAuthProvider('github')}
+                        disabled={loading || providersLoading}
+                      >
+                        {loading ? (
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        ) : (
+                          <Github className="w-5 h-5 mr-2" />
+                        )}
+                        Continue with GitHub
+                      </Button>
+                    )}
+
+                    {enabledProviders.apple && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full h-12 text-sm font-medium hover:bg-muted/50 transition-colors"
+                        onClick={() => handleOAuthProvider('apple')}
+                        disabled={loading || providersLoading}
+                      >
+                        {loading ? (
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        ) : (
+                          <Apple className="w-5 h-5 mr-2" />
+                        )}
+                        Continue with iCloud
+                      </Button>
+                    )}
+
+                    {!enabledProviders.google &&
+                     !enabledProviders.github &&
+                     !enabledProviders.apple && (
+                      <div className="text-center py-4">
+                        <p className="text-sm text-muted-foreground">OAuth providers not configured</p>
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,8 +6,11 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import SEO from "@/components/SEO";
 import { GuestBanner } from "@/components/GuestBanner";
+import { useSupabaseStats } from "@/hooks/useSupabaseStats";
 
 const Index = () => {
+  const { data: stats, isLoading, isError } = useSupabaseStats();
+
   return (
     <>
       <SEO
@@ -31,19 +34,25 @@ const Index = () => {
           <h1 className="text-5xl md:text-7xl font-bold text-gradient mb-6">
             AS Agents
           </h1>
-          <p className="text-xl md:text-2xl text-muted-foreground max-w-3xl mx-auto mb-8">
+          <p className="text-xl md:text-2xl text-muted-foreground max-w-3xl mx-auto mb-2">
             Professional construction management platform for modern businesses
+          </p>
+          <p className="text-sm text-muted-foreground max-w-3xl mx-auto mb-8">
+            {isLoading
+              ? "Loading stats..."
+              : isError
+                ? "Failed to load stats."
+                : `Managing ${stats?.projects ?? 0} projects and ${stats?.clients ?? 0} clients.`}
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link to="/dashboard">
-              <button className="btn-primary">
-                Enter Dashboard
-              </button>
+              <Button>Enter Dashboard</Button>
             </Link>
             <Link to="/agents">
-              <button className="btn-secondary">
-                AI Agents
-              </button>
+              <Button variant="secondary">AI Agents</Button>
+            </Link>
+            <Link to="/register">
+              <Button variant="secondary">Register</Button>
             </Link>
           </div>
         </div>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,0 +1,11 @@
+import SEO from "@/components/SEO";
+import Auth from "./Auth";
+
+export default function Register() {
+  return (
+    <>
+      <SEO title="Register" description="Create an account" />
+      <Auth defaultMode="signup" />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- surface loading and error states for Supabase stats on the homepage and switch hero actions to Button components
- add SEO metadata to the registration page
- refactor homepage stats loading into a dedicated React Query hook and document Supabase env vars

## Testing
- `VITE_SUPABASE_URL="https://example.supabase.co" VITE_SUPABASE_PUBLISHABLE_KEY="public-anon-key" VITE_RESEND_API_KEY="dummy" npm test`


------
https://chatgpt.com/codex/tasks/task_b_68abbf44a3fc832abbb51a222dc48ba3